### PR TITLE
Issue 10: adding in jruby-head mode to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ rvm:
   - 2.1.5
   - 2.2.0
   - jruby-19mode # JRuby in 1.9 mode
+  - jruby-head


### PR DESCRIPTION
Adding in `jruby-head` to Travis CI Ruby versions.
