### PR TITLE
Issue 24: adding new private method for kth statistic computation. Tests...

### DIFF
--- a/lib/frequent/algorithm.rb
+++ b/lib/frequent/algorithm.rb
@@ -3,6 +3,9 @@ require 'frequent/version'
 
 module Frequent
 
+  ERR_BADLIST = "List cannot be nil or empty".freeze
+  ERR_BADK = "k must be between 1 and %s".freeze
+
   # `Frequent::Algorithm` is the Ruby implementation of the
   # Demaine et al. FREQUENT algorithm for calculating 
   # top-k items in a stream.
@@ -25,7 +28,7 @@ module Frequent
     attr_reader :statistics
     # @return [Integer] minimum threshold for membership in top-k items
     attr_reader :delta
-    
+
     # Initializes this top-k frequency-calculating instance.
     # 
     # @param [Integer] n number of items in the main window
@@ -96,7 +99,7 @@ module Frequent
 
       # Step 5
       @delta += summary[kth_index][1]
-      
+
       # Step 6
       if should_pop_oldest_summary
         # a
@@ -122,39 +125,64 @@ module Frequent
     end
 
     private
-      # Return true when it is ready to pop oldest summary from queue
-      #
-      # @return [Boolean] whether it is ready to pop oldest summary from queue
-      def should_pop_oldest_summary
-        @queue.length > @n/@b
-      end
+    # Return true when it is ready to pop oldest summary from queue
+    #
+    # @return [Boolean] whether it is ready to pop oldest summary from queue
+    def should_pop_oldest_summary
+      @queue.length > @n/@b
+    end
 
-      # Return the k-th index of a summary object
-      #
-      # @param [Object] a summary object
-      # @return [Integer] the k-th index
-      def find_kth_largest(summary)
-        [summary.length, @k].min - 1
+    # Return the k-th index of a summary object
+    #
+    # @param [Object] a summary object
+    # @return [Integer] the k-th index
+    def find_kth_largest(summary)
+      [summary.length, @k].min - 1
+    end
+
+    # Return the kth largest element in the given list.
+    #
+    # @param [Array] list of integers
+    # @return [Integer] the k-th largest element in list
+    def kth_largest(list, k)
+      raise ArgumentError.new(ERR_BADLIST) if list.nil? or list.empty?
+      raise ArgumentError.new(ERR_BADK) if k < 1 or k > list.size
+
+      def quickselect(ulist, k)
+        p = rand(ulist.size)
+
+        lower = ulist.select { |e| e < ulist[p] }
+        upper = ulist.select { |e| e > ulist[p] }
+
+        if k <= lower.size
+          quickselect(lower, k)
+        elsif k > ulist.size - upper.size
+          quickselect(upper, k - (ulist.size - upper.size))
+        else
+          ulist[p]
+        end
       end
+      quickselect(list, list.size+1-k)
+    end
   end
 end
 
 =begin
 
   The MIT License (MIT)
-  
+
   Copyright (c) 2015 Willie Tong, Brooke M. Fujita
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
   the rights to use, copy, modify, merge, publish, distribute, sublicense,
   and/or sell copies of the Software, and to permit persons to whom the 
   Software is furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included
   in all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/test/frequent/tc_algorithm.rb
+++ b/test/frequent/tc_algorithm.rb
@@ -91,6 +91,55 @@ class TestAlgorithm < MiniTest::Unit::TestCase
     assert_equal(0, @alg.statistics.size)
     assert_equal(0, @alg.delta)
   end
+
+  def test_kth_largest
+    Frequent::Algorithm.expose_privates do
+
+      assert_raises ArgumentError do
+        @alg.kth_largest(nil, 6)
+      end
+
+      assert_raises ArgumentError do
+        @alg.kth_largest([], 6)
+      end
+
+      a1 = [1,2,3,4,5]
+      assert_equal(5, @alg.kth_largest(a1, 1))
+      assert_equal(4, @alg.kth_largest(a1, 2))
+      assert_equal(3, @alg.kth_largest(a1, 3))
+      assert_equal(2, @alg.kth_largest(a1, 4))
+      assert_equal(1, @alg.kth_largest(a1, 5))
+      assert_raises ArgumentError do
+        @alg.kth_largest(a1, 0)
+      end
+      assert_raises ArgumentError do
+        @alg.kth_largest(a1, 6)
+      end
+      
+      a2 = [2,2,4,4,1]
+      assert_equal(4, @alg.kth_largest(a2, 1))
+      assert_equal(4, @alg.kth_largest(a2, 2))
+      assert_equal(2, @alg.kth_largest(a2, 3))
+      assert_equal(2, @alg.kth_largest(a2, 4))
+      assert_equal(1, @alg.kth_largest(a2, 5))
+
+      a3 = [1,1,2,1,1,1]
+      assert_equal(2, @alg.kth_largest(a3, 1))
+      assert_equal(1, @alg.kth_largest(a3, 2))
+      assert_equal(1, @alg.kth_largest(a3, 3))
+      assert_equal(1, @alg.kth_largest(a3, 4))
+      assert_equal(1, @alg.kth_largest(a3, 5))
+      assert_equal(1, @alg.kth_largest(a3, 6))
+
+      a4 = [1,1,1,1,1,1]
+      assert_equal(1, @alg.kth_largest(a4, 1))
+      assert_equal(1, @alg.kth_largest(a4, 2))
+      assert_equal(1, @alg.kth_largest(a4, 3))
+      assert_equal(1, @alg.kth_largest(a4, 4))
+      assert_equal(1, @alg.kth_largest(a4, 5))
+      assert_equal(1, @alg.kth_largest(a4, 6))
+    end
+  end
 end
 
 =begin

--- a/test/test_frequent-algorithm.rb
+++ b/test/test_frequent-algorithm.rb
@@ -7,6 +7,15 @@ require 'frequent-algorithm'
   require File.join(File.expand_path('.'), tc)
 end
 
+class Class
+  def expose_privates
+    saved_private_instance_methods = self.private_instance_methods
+    self.class_eval { public *saved_private_instance_methods }
+    yield
+    self.class_eval { private *saved_private_instance_methods }
+  end
+end
+
 =begin
 
   The MIT License (MIT)


### PR DESCRIPTION
... included.

When processing the summaries in the queue, we don't really need to sort or know _where_ in the data structure of the summary the kth largest element is... We only need to know _what_ the kth largest element is.

New private method `kth_largest` does just that using the quickselect algorithm. c.f. Ch. 9, Medians and Order Statistics, Introduction to Algorithms, Cormen, Leisorson, Rivest and Stein.
