### PR TITLE
Enhancements for Issue #24

### DIFF
--- a/lib/frequent/algorithm.rb
+++ b/lib/frequent/algorithm.rb
@@ -79,35 +79,32 @@ module Frequent
         end
       end
 
-      # index of the k-th item
-      kth_index = find_kth_largest(summary)
-
-      # Step 2 & 3
-      # summary is [[item,count],[item,count],[item,count]....]
-      # sorted by descending order of the item count
-      summary = summary.sort { |a,b| b[1]<=>a[1] }[0..kth_index]
+      # Step 2
       @queue << summary
 
+      # Step 3
+      # Done, implicitly
+
       # Step 4
-      summary.each do |t|
-        if @statistics.key? t[0]
-          @statistics[t[0]] += t[1]
+      summary.each do |k,v|
+        if @statistics.key? k
+          @statistics[k] += v
         else
-          @statistics[t[0]] = t[1]
+          @statistics[k] = v
         end
       end
 
       # Step 5
-      @delta += summary[kth_index][1]
+      @delta += kth_largest(summary.values, @k)
 
-      # Step 6
-      if should_pop_oldest_summary
+      # Step 6 - sizeOf(Q) > N/b
+      if @queue.length > @n/@b
         # a
         summary_p = @queue.shift
-        @delta -= summary_p[find_kth_largest(summary_p)][1]
+        @delta -= kth_largest(summary_p.values, @k)
 
         # b
-        summary_p.each { |t| @statistics[t[0]] -= t[1] }
+        summary_p.each { |k,v| @statistics[k] -= v }
         @statistics.delete_if { |k,v| v <= 0 }
 
         #c
@@ -125,28 +122,15 @@ module Frequent
     end
 
     private
-    # Return true when it is ready to pop oldest summary from queue
-    #
-    # @return [Boolean] whether it is ready to pop oldest summary from queue
-    def should_pop_oldest_summary
-      @queue.length > @n/@b
-    end
-
-    # Return the k-th index of a summary object
-    #
-    # @param [Object] a summary object
-    # @return [Integer] the k-th index
-    def find_kth_largest(summary)
-      [summary.length, @k].min - 1
-    end
-
     # Return the kth largest element in the given list.
     #
     # @param [Array] list of integers
     # @return [Integer] the k-th largest element in list
     def kth_largest(list, k)
       raise ArgumentError.new(ERR_BADLIST) if list.nil? or list.empty?
-      raise ArgumentError.new(ERR_BADK) if k < 1 or k > list.size
+      raise ArgumentError.new(ERR_BADK) if k < 1
+
+      return list.last if k > list.size
 
       def quickselect(ulist, k)
         p = rand(ulist.size)

--- a/test/frequent/tc_algorithm.rb
+++ b/test/frequent/tc_algorithm.rb
@@ -23,14 +23,14 @@ class TestAlgorithm < MiniTest::Unit::TestCase
     topk = @alg.process(data30[0]) # only 1 summary in queue...
     # 3141592653
     assert_equal(1, @alg.queue.length)
-    assert_equal(3, @alg.statistics.length)
+    assert_equal(7, @alg.statistics.length)
     assert_equal(2, @alg.delta)
     assert_equal(0, topk.length)
 
     topk = @alg.process(data30[1]) # 2nd summary in queue...
     # 5897932384
     assert_equal(2, @alg.queue.length)
-    assert_equal(5, @alg.statistics.length)
+    assert_equal(9, @alg.statistics.length)
     assert_equal(4, @alg.delta)
     assert_equal(0, topk.length)
 
@@ -39,7 +39,8 @@ class TestAlgorithm < MiniTest::Unit::TestCase
     topk = @alg.process(data30[2]) # 3rd summary, delta updated
     # 6264338327
     assert_equal(2, @alg.queue.length)
-    assert_equal(5, @alg.statistics.length)
+    assert_equal(8, @alg.statistics.length)
+    assert_nil(@alg.statistics['1'])
     assert_equal(4, @alg.delta)
     assert_equal(1, topk.length)
     assert_equal(5, topk['3'])
@@ -55,7 +56,7 @@ class TestAlgorithm < MiniTest::Unit::TestCase
 
     topk = @alg.process(%w(1 1 1 2 2 2 3 3 3 4)) #2nd summary in queue...
     assert_equal(2, @alg.queue.length)
-    assert_equal(3, @alg.statistics.length)
+    assert_equal(4, @alg.statistics.length)
     assert_equal(7, @alg.delta)
     assert_equal(0, topk.length)
 
@@ -64,10 +65,11 @@ class TestAlgorithm < MiniTest::Unit::TestCase
     # the first summary with 2 items was used as S'
     topk = @alg.process(%w(1 1 1 2 2 3 3 3 3 4)) # 3rd summary, delta updated
     assert_equal(2, @alg.queue.length)
-    assert_equal(3, @alg.statistics.length)
+    assert_equal(4, @alg.statistics.length)
     assert_equal(5, @alg.delta)
     assert_equal(2, topk.length)
     assert_equal(7, topk['3'])
+    assert_equal(6, topk['1'])
   end
 
   def test_init
@@ -112,9 +114,7 @@ class TestAlgorithm < MiniTest::Unit::TestCase
       assert_raises ArgumentError do
         @alg.kth_largest(a1, 0)
       end
-      assert_raises ArgumentError do
-        @alg.kth_largest(a1, 6)
-      end
+      assert_equal(5, @alg.kth_largest(a1, 6))
       
       a2 = [2,2,4,4,1]
       assert_equal(4, @alg.kth_largest(a2, 1))


### PR DESCRIPTION
Use `kth_largest` method and got rid of the `[[][]]` data structure.

I had to make some changes in `kth_largest` to handle the case when the list size is smaller than k (when there are fewer unique items among the b numbers of data in a window).
